### PR TITLE
Fix profile test

### DIFF
--- a/pages/register.py
+++ b/pages/register.py
@@ -72,10 +72,14 @@ class SkillsAndGroupsTab(Register):
     def add_language(self, language_name):
         element = self.selenium.find_element(*self._language_field_locator)
         element.send_keys(language_name)
+        # send tab to make the entry "stick"
+        element.send_keys("\t")
 
     def add_skill(self, skill_name):
         element = self.selenium.find_element(*self._skills_field_locator)
         element.send_keys(skill_name)
+        # send tab to make the entry "stick"
+        element.send_keys("\t")
 
     def click_next_button(self):
         self.selenium.find_element(*self._next_button_locator).click()

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -117,4 +117,6 @@ class TestProfile(BaseTest):
         Assert.equal('New MozilliansUser', profile_page.name)
         Assert.equal(user['email'], profile_page.email)
         Assert.equal("Hello, I'm new here and trying stuff out. Oh, and by the way: I'm a robot, run in a cronjob, most likely", profile_page.biography)
+        Assert.equal('test', profile_page.skills)
+        Assert.equal('english', profile_page.languages)
         Assert.equal('Mountain View, California\nUnited States', profile_page.location)


### PR DESCRIPTION
This fixes the failure on Jenkins for mozillians.dev [1]. The test is failing because we are asserting on two fields that are no longer there. While this fix allows the test to pass, I think we first need to verify that those fields were intentionally removed. If they were not this may in fact be a bug, rather than a change required for the test.

[1] http://qa-selenium.mv.mozilla.com:8080/job/mozillians.dev/2794/testReport/tests.test_profile/TestProfile/test_profile_creation/
