### PR TITLE
Remove search tests

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -41,18 +41,3 @@ class TestSearch:
         home_page.header.search_for(u'stephend')
         profile = Profile(mozwebqa)
         Assert.equal(u'Stephen Donner', profile.name)
-
-    @pytest.mark.nondestructive
-    def test_search_function_only_present_for_vouched_users(self, mozwebqa):
-        home_page = Home(mozwebqa)
-        Assert.false(home_page.header.is_search_box_present)
-        home_page.login()
-        Assert.true(home_page.header.is_search_box_present)
-
-    @pytest.mark.nondestructive
-    def test_search_for_no_results(self, mozwebqa):
-        home_page = Home(mozwebqa)
-        home_page.login()
-        search_page = home_page.header.search_for(u',')
-        Assert.contains(u'Sorry, we cannot find a group or person related to ",".', search_page.no_results_message_head)  # changed '.' => to ',' as workaround for selenium issue 4608
-        Assert.equal(u'Maybe they\'re not a Mozillian yet? Invite this person to create a profile.', search_page.no_results_message_body)


### PR DESCRIPTION
Removing search tests that fall into two categories:
- Tests that already have coverage provided by <a href="https://github.com/mozilla/mozillians/blob/master/apps/phonebook/tests/test_search.py">webdev's tests</a>.
- Tests that don't correctly provide coverage and provide a false sense of security - these need to be reworked to follow the proper workflow. I will file the appropriate git issues in webdev's & webqa's repos.
