### PR TITLE
update error message locator for invite error message

### DIFF
--- a/pages/invite.py
+++ b/pages/invite.py
@@ -14,7 +14,7 @@ class Invite(Base):
 
     _recipient_field_locator = (By.ID, 'id_recipient')
     _send_invite_button_locator = (By.CSS_SELECTOR, '#main button')
-    _error_text_locator = (By.CSS_SELECTOR, '.errorlist > li')
+    _error_text_locator = (By.CSS_SELECTOR, '.help-inline')
 
     @property
     def error_text_message(self):


### PR DESCRIPTION
A small tweak to the locator. In the future we may want to change <code>test_inviting_an_invalid_email_address(self, mozwebqa)</code> to use a <code>contains</code> instead of an <code>equals</code>. I've done this for simplicity's sake. Down with the gold plating.
