### PR TITLE
302 tests

### DIFF
--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -6,11 +6,7 @@
 
 import pytest
 import requests
-
 from unittestzero import Assert
-
-
-xfail = pytest.mark.xfail
 
 
 @pytest.mark.skip_selenium
@@ -31,7 +27,6 @@ class TestRedirects:
              '/en-US/invite/']
 
     @pytest.mark.xfail(reason='Disabled until Bug 846039 is fixed')
-    @pytest.mark.skip_selenium
     @pytest.mark.nondestructive
     def test_302_redirect_for_anonomous_users(self, mozwebqa):
         error_list = []


### PR DESCRIPTION
Several redirect tests. An <i>anonymous</i> user who isn't logged in or doesn't have an account should encounter an HTTP 302 when they access these paths. 
