### PR TITLE
remove xfail for the HTTP 200 tests

### DIFF
--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -33,7 +33,6 @@ class TestRedirects:
 
         Assert.equal(0, len(error_list), error_list)
 
-    @pytest.mark.xfail(reason='Bug 846039 - Create additional authorization-state-specific routing rules')
     @pytest.mark.nondestructive
     def test_200_for_anonymous_users(self, mozwebqa):
         paths = ['/pl/opensearch.xml', '/nl/u/MozilliansUser/']


### PR DESCRIPTION
The HTTP 200 redirect tests appear to be passing again on:
- mozillians.org (prod)
- mozillians.allizom.org (stage)
- mozillians-dev.allizom.org (dev)
  
  ```
  mbrandt$ py.test --baseurl=https://mozillians-dev.allizom.org tests/test_redirects.py -k 200
  ==== 1 tests deselected by "-k200 -m 'nondestructive'" ====
  ==== 1 passed, 1 deselected in 0.64 seconds ====
  ```
