### PR TITLE
remove xfails for login-logout tests

### DIFF
--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -13,7 +13,6 @@ from pages.link_crawler import LinkCrawler
 
 class TestAccount:
 
-    @pytest.mark.xfail("config.getvalue('base_url') != 'https://mozillians.org'", reason="Bug 934319 - Unable to properly log out of Mozillians-dev and stage")
     @pytest.mark.nondestructive
     def test_login_logout(self, mozwebqa):
         home_page = Home(mozwebqa)
@@ -23,7 +22,6 @@ class TestAccount:
         home_page.header.click_logout_menu_item()
         Assert.true(home_page.is_browserid_link_present)
 
-    @pytest.mark.xfail("config.getvalue('base_url') != 'https://mozillians.org'", reason="Bug 934319 - Unable to properly log out of Mozillians-dev and stage")
     @pytest.mark.nondestructive
     def test_logout_verify_bid(self, mozwebqa):
         # issue https://github.com/mozilla/mozillians-tests/issues/99


### PR DESCRIPTION
<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=933907">Bug 933907</a> has been remedied; this pull request removes the xfails.
