### PR TITLE
xfail filter by city test

### DIFF
--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -212,6 +212,8 @@ class TestProfile(BaseTest):
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
+    @pytest.mark.xfail("'allizom' in config.getvalue('base_url')",
+                       reason="Bug 1025160 - [stage][regression] location based search results are incorrect")
     def test_that_filter_by_city_works(self, mozwebqa):
         home_page = Home(mozwebqa)
         home_page.login()


### PR DESCRIPTION
Filtering by location [search] has regressed on dev and stage. adding a `xfail`
