### PR TITLE
removed **kwargs from location search

### DIFF
--- a/pages/location_search_results.py
+++ b/pages/location_search_results.py
@@ -18,15 +18,6 @@ class LocationSearchResults(Base):
     _result_item_locator = (By.CSS_SELECTOR, 'div.row > div.result')
 
     @property
-    def _page_title(self):
-        if hasattr(self, 'region'):
-            return u'Mozillians: %s, %s' % (self.region, self.country)
-        elif hasattr(self, 'city'):
-            return u'Mozillians: %s, %s' % (self.city, self.country)
-        else:
-            return u'Mozillians: %s' % self.country
-
-    @property
     def title(self):
         return self.find_element(*self._results_title_locator).text
 

--- a/pages/profile.py
+++ b/pages/profile.py
@@ -84,20 +84,20 @@ class Profile(Base):
     def country(self):
         return self.find_element(*self._country_locator).text
 
-    def click_city_name(self, **kwargs):
+    def click_profile_city_filter(self):
         self.find_element(*self._city_locator).click()
         from location_search_results import LocationSearchResults
-        return LocationSearchResults(self.testsetup, **kwargs)
+        return LocationSearchResults(self.testsetup)
 
-    def click_region_name(self, **kwargs):
+    def click_profile_region_filter(self,):
         self.find_element(*self._region_locator).click()
         from location_search_results import LocationSearchResults
-        return LocationSearchResults(self.testsetup, **kwargs)
+        return LocationSearchResults(self.testsetup)
 
-    def click_country_name(self, **kwargs):
+    def click_profile_country_filter(self):
         self.find_element(*self._country_locator).click()
         from location_search_results import LocationSearchResults
-        return LocationSearchResults(self.testsetup, **kwargs)
+        return LocationSearchResults(self.testsetup)
 
     @property
     def languages(self):
@@ -106,7 +106,7 @@ class Profile(Base):
     @property
     def profile_message(self):
         return self.selenium.find_element(*self._profile_message_locator).text
-    
+
     @property
     def is_groups_present(self):
         return self.is_element_present(*self._groups_locator)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -219,11 +219,11 @@ class TestProfile(BaseTest):
         profile_page = home_page.open_user_profile(u'Mozillians.User')
         city = profile_page.city
         country = profile_page.country
-        search_results_page = profile_page.click_city_name(city=city, country=country)
+
+        search_results_page = profile_page.click_profile_city_filter()
         expected_results_title = u'Mozillians in %s, %s' % (city, country)
         actual_results_title = search_results_page.title
 
-        Assert.true(search_results_page.is_the_current_page)
         Assert.equal(
             expected_results_title, actual_results_title,
             u'''Search results title is incorrect.
@@ -245,11 +245,10 @@ class TestProfile(BaseTest):
         profile_page = home_page.open_user_profile(u'Mozillians.User')
         region = profile_page.region
         country = profile_page.country
-        search_results_page = profile_page.click_region_name(region=region, country=country)
+        search_results_page = profile_page.click_profile_region_filter()
         expected_results_title = u'Mozillians in %s, %s' % (region, country)
         actual_results_title = search_results_page.title
 
-        Assert.true(search_results_page.is_the_current_page)
         Assert.equal(
             expected_results_title, actual_results_title,
             u'''Search results title is incorrect.
@@ -270,11 +269,10 @@ class TestProfile(BaseTest):
 
         profile_page = home_page.open_user_profile(u'Mozillians.User')
         country = profile_page.country
-        search_results_page = profile_page.click_country_name(country=country)
+        search_results_page = profile_page.click_profile_country_filter()
         expected_results_title = u'Mozillians in %s' % country
         actual_results_title = search_results_page.title
 
-        Assert.true(search_results_page.is_the_current_page)
         Assert.equal(
             expected_results_title, actual_results_title,
             u'''Search results title is incorrect.


### PR DESCRIPTION
Removing -- `Assert.true(search_results_page.is_the_current_page)` -- as well as removing `**kwargs`. Albeit `**kwargs` is an interesting solution, I want it out of our code base because I think it hinders readability.
