### PR TITLE
remove csrf tests

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -15,7 +15,6 @@ from pages.page import Page
 
 class Base(Page):
 
-    _csrf_token_locator = (By.NAME, 'csrfmiddlewaretoken')
     _logout_locator = (By.ID, 'nav-logout')
 
     _pending_approval_locator = (By.ID, 'pending-approval')
@@ -28,10 +27,6 @@ class Base(Page):
     def page_title(self):
         WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.title)
         return self.selenium.title
-
-    @property
-    def is_csrf_token_present(self):
-        return self.is_element_present(*self._csrf_token_locator)
 
     @property
     def is_pending_approval_visible(self):

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -15,11 +15,8 @@ class TestAccount:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    @pytest.mark.xfail("'allizom' in config.getvalue('base_url')",
-                       reason="Bug 1000908 -  Upgrade django-browserid to v0.10")
     def test_login_logout(self, mozwebqa):
         home_page = Home(mozwebqa)
-        Assert.true(home_page.is_csrf_token_present)
         home_page.login()
         Assert.true(home_page.header.is_logout_menu_item_present)
         home_page.header.click_logout_menu_item()
@@ -27,12 +24,8 @@ class TestAccount:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    @pytest.mark.xfail("'allizom' in config.getvalue('base_url')",
-                       reason="Bug 1000908 -  Upgrade django-browserid to v0.10")
     def test_logout_verify_bid(self, mozwebqa):
-
         home_page = Home(mozwebqa)
-        Assert.true(home_page.is_csrf_token_present)
         home_page.login()
         Assert.true(home_page.header.is_logout_menu_item_present)
         home_page.logout_using_url()

--- a/tests/test_invite.py
+++ b/tests/test_invite.py
@@ -25,7 +25,6 @@ class TestInvite:
         home_page = Home(mozwebqa)
         home_page.login()
         invite_page = home_page.header.click_invite_menu_item()
-        Assert.true(invite_page.is_csrf_token_present)
         mail_address = "validuser@example.com"
         invite_success_page = invite_page.invite(mail_address)
         Assert.equal("%s has been invited to Mozillians. They'll receive an email with instructions on how to join.\

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -21,7 +21,6 @@ class TestProfile(BaseTest):
         home_page.login()
         edit_profile_page = home_page.header.click_edit_profile_menu_item()
         confirm_profile_delete_page = edit_profile_page.click_delete_profile_button()
-        Assert.true(confirm_profile_delete_page.is_csrf_token_present)
         Assert.true(confirm_profile_delete_page.is_confirm_text_present)
         Assert.true(confirm_profile_delete_page.is_cancel_button_present)
         Assert.true(confirm_profile_delete_page.is_delete_button_present)
@@ -34,7 +33,6 @@ class TestProfile(BaseTest):
 
         profile_page = home_page.header.click_view_profile_menu_item()
         edit_profile_page = home_page.header.click_edit_profile_menu_item()
-        Assert.true(edit_profile_page.is_csrf_token_present)
         current_time = str(time.time()).split('.')[0]
 
         # New profile data


### PR DESCRIPTION
Per a discussion in irc with the team [as well as <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1000908#c9">bug 1000908</a> we no longer need to validate the presence of a csrf token.

Included in this pr:
- remove all `csrf token` assertions
- remove the `xfails` for the login and logout tests
