### PR TITLE
update test to work with vouch refactor + some cleanup

### DIFF
--- a/pages/invite.py
+++ b/pages/invite.py
@@ -13,6 +13,7 @@ from pages.base import Base
 class Invite(Base):
 
     _recipient_field_locator = (By.ID, 'id_recipient')
+    _vouch_reason_field_locator = (By.ID, 'id_description')
     _send_invite_button_locator = (By.CSS_SELECTOR, '#main button')
     _error_text_locator = (By.CSS_SELECTOR, '.error-message')
 
@@ -20,9 +21,11 @@ class Invite(Base):
     def error_text_message(self):
         return self.selenium.find_element(*self._error_text_locator).text
 
-    def invite(self, email):
-        input_field = self.selenium.find_element(*self._recipient_field_locator)
-        input_field.send_keys(email)
+    def invite(self, email, reason=''):
+        email_field = self.selenium.find_element(*self._recipient_field_locator)
+        email_field.send_keys(email)
+        reason_field = self.selenium.find_element(*self._vouch_reason_field_locator)
+        reason_field.send_keys(reason)
         self.selenium.find_element(*self._send_invite_button_locator).click()
         from pages.invite_success import InviteSuccess
         return InviteSuccess(self.testsetup)

--- a/tests/test_invite.py
+++ b/tests/test_invite.py
@@ -25,7 +25,7 @@ class TestInvite:
         home_page = Home(mozwebqa)
         home_page.login()
         invite_page = home_page.header.click_invite_menu_item()
-        mail_address = "validuser@example.com"
-        invite_success_page = invite_page.invite(mail_address)
+        email_address = "user@example.com"
+        invite_success_page = invite_page.invite(email_address, 'Just a bot sending a test invite to a test account.')
         Assert.equal("%s has been invited to Mozillians. They'll receive an email with instructions on how to join.\
- You can invite another Mozillian if you like." % mail_address, invite_success_page.success_message)
+ You can invite another Mozillian if you like." % email_address, invite_success_page.success_message)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -324,13 +324,12 @@ class TestProfile(BaseTest):
     @pytest.mark.credentials
     @pytest.mark.nondestructive
     def test_private_groups_field_as_public_when_logged_in(self, mozwebqa):
-        home_page = Home(mozwebqa)
         # User has certain fields preset to values to run the test properly
-            # groups - private
-            # belongs to at least one group
-        credentials = mozwebqa.credentials['vouched_with_private_fields']
-
+        # groups - private
+        # belongs to at least one group
+        home_page = Home(mozwebqa)
         home_page.login('vouched_with_private_fields')
+
         profile_page = home_page.header.click_view_profile_menu_item()
         profile_page.view_profile_as('Public')
 


### PR DESCRIPTION
The new vouch refactor is scheduled to land on production this week. This pull request updates provides updates to `def test_private_groups_field_as_public_when_logged_in()` in preparation for the deploy.

Note: once this is merged this test will fail on prod. This is OK, the current workflow of the project is to have tests updated to pass on mozillians-dev.allizom.org and mozillians.allizom.org. Once the prod deploy occurs prod will pass again.
