### PR TITLE
Bug 938184 - Remove tests that add/delete groups from profile page

### DIFF
--- a/pages/edit_profile.py
+++ b/pages/edit_profile.py
@@ -22,7 +22,6 @@ class EditProfile(Base):
     _full_name_field_locator = (By.ID, 'id_full_name')
     _website_field_locator = (By.ID, 'id_externalaccount_set-0-identifier')
     _bio_field_locator = (By.ID, 'id_bio')
-    _groups_field_locator = (By.CSS_SELECTOR, '#id_groups + ul input')
     _skills_field_locator = (By.CSS_SELECTOR, '#id_skills + ul input')
     _groups_locator = (By.CSS_SELECTOR, "#groups .tagit-label")
     _skills_locator = (By.CSS_SELECTOR, "#skills .tagit-label")
@@ -30,7 +29,6 @@ class EditProfile(Base):
     _username_field_locator = (By.ID, 'id_username')
     _browserid_mail_locator = (By.CSS_SELECTOR, '.control-group:nth-of-type(2) .label-text')
     _delete_profile_button_locator = (By.CSS_SELECTOR, '.delete')
-    _delete_group_buttons_locator = (By.CSS_SELECTOR, '#groups .tagit-close')
     _delete_skill_buttons_locator = (By.CSS_SELECTOR, '#skills .tagit-close')
     _select_month_locator = (By.ID, 'id_date_mozillian_month')
     _select_year_locator = (By.ID, 'id_date_mozillian_year')
@@ -67,11 +65,6 @@ class EditProfile(Base):
         element = self.selenium.find_element(*self._bio_field_locator)
         element.clear()
         element.send_keys(biography)
-
-    def add_group(self, group_name):
-        element = self.selenium.find_element(*self._groups_field_locator)
-        element.send_keys(group_name)
-        element.send_keys(Keys.RETURN)
 
     def add_skill(self, skill_name):
         element = self.selenium.find_element(*self._skills_field_locator)
@@ -134,10 +127,6 @@ class EditProfile(Base):
     def skills(self):
         skills = self.selenium.find_elements(*self._skills_locator)
         return [skills[i].text for i in range(0, len(skills))]
-
-    @property
-    def delete_group_buttons(self):
-        return self.selenium.find_elements(*self._delete_group_buttons_locator)
 
     @property
     def delete_skill_buttons(self):

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -55,41 +55,6 @@ class TestProfile:
         Assert.equal(biography, new_biography)
         Assert.equal(website, new_website)
 
-    @pytest.mark.xfail("'allizom' in config.getvalue('base_url')",
-                       reason="Bug 938184 - Users should not create, join, or leave groups from the profile create/edit screens")
-    @pytest.mark.credentials
-    def test_group_addition(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
-        home_page.login(vouched_user['email'], vouched_user['password'])
-        edit_profile_page = home_page.header.click_edit_profile_menu_item()
-        edit_profile_page.add_group("Hello World")
-        profile_page = edit_profile_page.click_update_button()
-
-        Assert.true(profile_page.is_groups_present, "No groups added to profile.")
-        groups = profile_page.groups
-        Assert.greater(groups.find("hello world"), -1, "Group 'Hello World' not added to profile.")
-
-    @pytest.mark.xfail("'allizom' in config.getvalue('base_url')",
-                       reason="Bug 938184 - Users should not create, join, or leave groups from the profile create/edit screens")
-    @pytest.mark.credentials
-    def test_group_deletion(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
-        home_page.login(vouched_user['email'], vouched_user['password'])
-
-        edit_profile_page = home_page.header.click_edit_profile_menu_item()
-        edit_profile_page.add_group("Hello World")
-        profile_page = edit_profile_page.click_update_button()
-        edit_profile_page = profile_page.header.click_edit_profile_menu_item()
-
-        groups = edit_profile_page.groups
-        group_delete_buttons = edit_profile_page.delete_group_buttons
-        group_delete_buttons[groups.index("hello world")].click()
-        profile_page = edit_profile_page.click_update_button()
-
-        if profile_page.is_groups_present:
-            groups = profile_page.groups
-            Assert.equal(groups.find("hello world"), -1, "Group 'hello world' not deleted.")
-
     @pytest.mark.credentials
     def test_skill_addition(self, mozwebqa, vouched_user):
         home_page = Home(mozwebqa)


### PR DESCRIPTION
We don't run these tests on production as they're destructive, and they're xfailed on other environments because the feature appears to have been removed. Let's clean up and remove the tests. Pinging @m8ttyB for review.