### PR TITLE
Migrate to pytest-selenium

### DIFF
--- a/mozwebqa.cfg
+++ b/mozwebqa.cfg
@@ -1,3 +1,0 @@
-[DEFAULT]
-api = webdriver
-baseurl = https://mozillians-dev.allizom.org

--- a/pages/base.py
+++ b/pages/base.py
@@ -25,7 +25,7 @@ class Base(Page):
 
     @property
     def page_title(self):
-        WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.title)
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.selenium.title)
         return self.selenium.title
 
     @property
@@ -54,7 +54,7 @@ class Base(Page):
         from browserid import BrowserID
         pop_up = BrowserID(self.selenium, self.timeout)
         pop_up.sign_in(email, password)
-        WebDriverWait(self.selenium, 20).until(lambda s: self.is_user_loggedin)
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_user_loggedin)
 
     def create_new_user(self, email, password):
         self.click_browserid_login()
@@ -62,24 +62,24 @@ class Base(Page):
         pop_up = BrowserID(self.selenium, self.timeout)
         pop_up.sign_in(email, password)
 
-        WebDriverWait(self.selenium, 20).until(lambda s: self.is_user_loggedin)
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_user_loggedin)
         from pages.register import Register
-        return Register(self.testsetup)
+        return Register(self.base_url, self.selenium)
 
     # Logged in
 
     @property
     def header(self):
-        return self.Header(self.testsetup)
+        return self.Header(self.base_url, self.selenium)
 
     @property
     def footer(self):
-        return self.Footer(self.testsetup)
+        return self.Footer(self.base_url, self.selenium)
 
     def open_user_profile(self, username):
         self.get_relative_path(u'/u/%s' % username)
         from pages.profile import Profile
-        return Profile(self.testsetup)
+        return Profile(self.base_url, self.selenium)
 
     def logout_using_url(self):
         self.get_relative_path(u'/logout')
@@ -105,7 +105,7 @@ class Base(Page):
             search_field.send_keys(search_term)
             search_field.send_keys(Keys.RETURN)
             from pages.search import Search
-            return Search(self.testsetup)
+            return Search(self.base_url, self.selenium)
 
         def click_options(self):
             self.selenium.find_element(*self._profile_menu_locator).click()
@@ -120,19 +120,19 @@ class Base(Page):
             self.click_options()
             self.selenium.find_element(*self._view_profile_menu_item_locator).click()
             from pages.profile import Profile
-            return Profile(self.testsetup)
+            return Profile(self.base_url, self.selenium)
 
         def click_invite_menu_item(self):
             self.click_options()
             self.selenium.find_element(*self._invite_menu_item_locator).click()
             from pages.invite import Invite
-            return Invite(self.testsetup)
+            return Invite(self.base_url, self.selenium)
 
         def click_edit_profile_menu_item(self):
             self.click_options()
             self.selenium.find_element(*self._edit_profile_menu_item_locator).click()
             from pages.edit_profile import EditProfile
-            return EditProfile(self.testsetup)
+            return EditProfile(self.base_url, self.selenium)
 
         def click_logout_menu_item(self):
             self.click_options()
@@ -148,7 +148,7 @@ class Base(Page):
         def click_about_link(self):
             self.selenium.find_element(*self._about_mozillians_link_locator).click()
             from pages.about import About
-            return About(self.testsetup)
+            return About(self.base_url, self.selenium)
 
         def select_language(self, lang_code):
             element = self.selenium.find_element(*self._language_selector_locator)

--- a/pages/edit_profile.py
+++ b/pages/edit_profile.py
@@ -42,14 +42,14 @@ class EditProfile(Base):
 
     def click_update_button(self):
         self.selenium.find_element(*self._update_button_locator).click()
-        return Profile(self.testsetup)
+        return Profile(self.base_url, self.selenium)
 
     def click_cancel_button(self):
         self.selenium.find_element(*self._cancel_button_locator).click()
 
     def click_find_group_link(self):
         self.selenium.find_element(*self._find_group_page).click()
-        return GroupsPage(self.testsetup)
+        return GroupsPage(self.base_url, self.selenium)
 
     def set_full_name(self, full_name):
         element = self.selenium.find_element(*self._full_name_field_locator)
@@ -87,7 +87,7 @@ class EditProfile(Base):
         self.selenium.find_element(*self._acknowledge_deletion_checkbox_locator).click()
         self.selenium.find_element(*self._delete_profile_button_locator).click()
         from pages.confirm_profile_delete import ConfirmProfileDelete
-        return ConfirmProfileDelete(self.testsetup)
+        return ConfirmProfileDelete(self.base_url, self.selenium)
 
     def select_month(self, option_month):
         element = self.selenium.find_element(*self._select_month_locator)

--- a/pages/group_info_page.py
+++ b/pages/group_info_page.py
@@ -17,4 +17,4 @@ class GroupInfoPage(Base):
     def delete_group(self):
         self.selenium.find_element(*self._delete_group_button).click()
         from pages.groups_page import GroupsPage
-        return GroupsPage(self.testsetup)
+        return GroupsPage(self.base_url, self.selenium)

--- a/pages/groups_page.py
+++ b/pages/groups_page.py
@@ -17,7 +17,7 @@ class GroupsPage(Base):
 
     def click_create_group_main_button(self):
         self.selenium.find_element(*self._create_group_main_button).click()
-        return CreateGroupPage(self.testsetup)
+        return CreateGroupPage(self.base_url, self.selenium)
 
     def wait_for_alert_message(self):
         self.wait_for_element_visible(*self._alert_message_locator)

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -10,21 +10,20 @@ from pages.base import Base
 
 class Home(Base):
 
-    def __init__(self, testsetup, open_url=True):
-        Base.__init__(self, testsetup)
-        self.maximize_window()
+    def __init__(self, base_url, selenium, open_url=True):
+        Base.__init__(self, base_url, selenium)
         if open_url:
             self.selenium.get(self.base_url)
 
     def go_to_localized_edit_profile_page(self, non_US):
         self.get_relative_path("/" + non_US + "/user/edit/")
         from pages.edit_profile import EditProfile
-        return EditProfile(self.testsetup)
+        return EditProfile(self.base_url, self.selenium)
 
     def wait_for_user_login(self):
         # waits to see if user gets logged back in
         # if not then all ok
         try:
-            WebDriverWait(self.selenium, 20).until(lambda s: self.is_user_loggedin)
+            WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_user_loggedin)
         except Exception:
             pass

--- a/pages/invite.py
+++ b/pages/invite.py
@@ -28,4 +28,4 @@ class Invite(Base):
         reason_field.send_keys(reason)
         self.selenium.find_element(*self._send_invite_button_locator).click()
         from pages.invite_success import InviteSuccess
-        return InviteSuccess(self.testsetup)
+        return InviteSuccess(self.base_url, self.selenium)

--- a/pages/link_crawler.py
+++ b/pages/link_crawler.py
@@ -8,10 +8,11 @@ import requests
 from BeautifulSoup import BeautifulSoup
 from unittestzero import Assert
 
-from pages.page import Page
 
+class LinkCrawler(object):
 
-class LinkCrawler(Page):
+    def __init__(self, base_url):
+        self.base_url = base_url
 
     def collect_links(self, url, relative=True, name=True, **kwargs):
         """Collects links for given page URL.

--- a/pages/location_search_results.py
+++ b/pages/location_search_results.py
@@ -19,16 +19,16 @@ class LocationSearchResults(Base):
 
     @property
     def title(self):
-        return self.find_element(*self._results_title_locator).text
+        return self.selenium.find_element(*self._results_title_locator).text
 
     @property
     def results_count(self):
-        return len(self.find_elements(*self._result_item_locator))
+        return len(self.selenium.find_elements(*self._result_item_locator))
 
     @property
     def search_results(self):
-        return [self.SearchResult(self.testsetup, web_element)
-                for web_element in self.find_elements(*self._result_item_locator)]
+        return [self.SearchResult(self.base_url, self.selenium, el) for el in
+                self.selenium.find_elements(*self._result_item_locator)]
 
     def get_random_profile(self):
         random_index = randrange(self.results_count)
@@ -39,6 +39,6 @@ class LocationSearchResults(Base):
         _profile_page_link_locator = (By.CSS_SELECTOR, 'a')
 
         def open_profile_page(self):
-            self.find_element(*self._profile_page_link_locator).click()
+            self._root_element.find_element(*self._profile_page_link_locator).click()
             from pages.profile import Profile
-            return Profile(self.testsetup)
+            return Profile(self.base_url, self.selenium)

--- a/pages/profile.py
+++ b/pages/profile.py
@@ -30,8 +30,8 @@ class Profile(Base):
     _profile_message_locator = (By.CSS_SELECTOR, '.alert')
     _view_as_locator = (By.ID, 'view-privacy-mode')
 
-    def __init__(self, testsetup):
-        Base.__init__(self, testsetup)
+    def __init__(self, base_url, selenium):
+        Base.__init__(self, base_url, selenium)
         WebDriverWait(self.selenium, self.timeout).until(
             lambda s: self.is_element_visible(*self._profile_photo_locator))
 
@@ -74,30 +74,30 @@ class Profile(Base):
 
     @property
     def city(self):
-        return self.find_element(*self._city_locator).text
+        return self.selenium.find_element(*self._city_locator).text
 
     @property
     def region(self):
-        return self.find_element(*self._region_locator).text
+        return self.selenium.find_element(*self._region_locator).text
 
     @property
     def country(self):
-        return self.find_element(*self._country_locator).text
+        return self.selenium.find_element(*self._country_locator).text
 
     def click_profile_city_filter(self):
-        self.find_element(*self._city_locator).click()
+        self.selenium.find_element(*self._city_locator).click()
         from location_search_results import LocationSearchResults
-        return LocationSearchResults(self.testsetup)
+        return LocationSearchResults(self.base_url, self.selenium)
 
     def click_profile_region_filter(self,):
-        self.find_element(*self._region_locator).click()
+        self.selenium.find_element(*self._region_locator).click()
         from location_search_results import LocationSearchResults
-        return LocationSearchResults(self.testsetup)
+        return LocationSearchResults(self.base_url, self.selenium)
 
     def click_profile_country_filter(self):
-        self.find_element(*self._country_locator).click()
+        self.selenium.find_element(*self._country_locator).click()
         from location_search_results import LocationSearchResults
-        return LocationSearchResults(self.testsetup)
+        return LocationSearchResults(self.base_url, self.selenium)
 
     @property
     def languages(self):

--- a/pages/register.py
+++ b/pages/register.py
@@ -37,7 +37,7 @@ class Register(Base):
         element.send_keys(location)
         element.send_keys(Keys.RETURN)
         WebDriverWait(self.selenium, self.timeout).until(
-            lambda s: self._selenium_root.find_element(*self._country_locator).text != "")
+            lambda s: s.find_element(*self._country_locator).text != "")
 
     def set_full_name(self, full_name):
         element = self.selenium.find_element(*self._full_name_field_locator)
@@ -88,4 +88,4 @@ class Register(Base):
     def click_create_profile_button(self):
         self.selenium.find_element(*self._create_profile_button_locator).click()
         from pages.profile import Profile
-        return Profile(self.testsetup)
+        return Profile(self.base_url, self.selenium)

--- a/pages/search.py
+++ b/pages/search.py
@@ -8,7 +8,7 @@
 from selenium.webdriver.common.by import By
 
 from pages.base import Base
-from pages.page import Page
+from pages.page import PageRegion
 
 
 class Search(Base):
@@ -60,27 +60,23 @@ class Search(Base):
 
     @property
     def search_results(self):
-        return [self.SearchResult(self.testsetup, web_element) for web_element in
+        return [self.SearchResult(self.base_url, self.selenium, el) for el in
                 self.selenium.find_elements(*self._result_locator)]
 
     def open_group(self, name):
         self.selenium.find_element_by_link_text(name).click()
         from pages.group_info_page import GroupInfoPage
-        return GroupInfoPage(self.testsetup)
+        return GroupInfoPage(self.base_url, self.selenium)
 
-    class SearchResult(Page):
+    class SearchResult(PageRegion):
 
         _profile_page_link_locator = (By.CSS_SELECTOR, 'a')
         _name_locator = (By.CSS_SELECTOR, '.result .details h2')
 
-        def __init__(self, testsetup, root_element):
-            self._root_element = root_element
-            Page.__init__(self, testsetup)
-
         def open_profile_page(self):
             self._root_element.find_element(*self._profile_page_link_locator).click()
             from pages.profile import Profile
-            return Profile(self.testsetup)
+            return Profile(self.base_url, self.selenium)
 
         @property
         def name(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,7 @@
-# This pulls in all the libraries needed to run Selenium tests
-# on Mozilla WebQA projects
-
 UnittestZero
-certifi==0.0.8
-chardet==1.0.1
-py==1.4.26
-pytest==2.7.0
+pytest==2.7.3
 pytest-selenium
 pytest-variables
 requests==2.4.3
-selenium
 BeautifulSoup==3.2.1
 browserid

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ certifi==0.0.8
 chardet==1.0.1
 py==1.4.26
 pytest==2.7.0
-pytest-mozwebqa
+pytest-selenium
 pytest-variables
 requests==2.4.3
 selenium
 BeautifulSoup==3.2.1
--e git+https://github.com/mozilla/bidpom.git@master#egg=browserid
+browserid

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [flake8]
 ignore=E501
+
+[pytest]
+base_url=https://mozillians.allizom.org
+sensitive_url=mozillians\.org

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,19 @@ import pytest
 import requests
 
 
+@pytest.fixture(scope='session')
+def capabilities(capabilities):
+    capabilities.setdefault('tags', []).append('mozillians')
+    return capabilities
+
+
+@pytest.fixture
+def selenium(selenium):
+    selenium.implicitly_wait(10)
+    selenium.maximize_window()
+    return selenium
+
+
 @pytest.fixture
 def persona_test_user():
     return requests.get('http://personatestuser.org/email/').json()

--- a/tests/test_about_page.py
+++ b/tests/test_about_page.py
@@ -14,16 +14,15 @@ from pages.link_crawler import LinkCrawler
 class TestAboutPage:
 
     @pytest.mark.nondestructive
-    def test_about_page(self, mozwebqa):
-        home_page = Home(mozwebqa)
+    def test_about_page(self, base_url, selenium):
+        home_page = Home(base_url, selenium)
         about_mozillians_page = home_page.footer.click_about_link()
         Assert.true(about_mozillians_page.is_privacy_section_present)
         Assert.true(about_mozillians_page.is_get_involved_section_present)
 
-    @pytest.mark.skip_selenium
     @pytest.mark.nondestructive
-    def test_that_links_in_the_about_page_return_200_code(self, mozwebqa):
-        crawler = LinkCrawler(mozwebqa)
+    def test_that_links_in_the_about_page_return_200_code(self, base_url):
+        crawler = LinkCrawler(base_url)
         urls = crawler.collect_links('/about', id='main')
         bad_urls = []
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -15,8 +15,8 @@ class TestAccount:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_login_logout(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_login_logout(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         Assert.true(home_page.header.is_logout_menu_item_present)
         home_page.header.click_logout_menu_item()
@@ -24,8 +24,8 @@ class TestAccount:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_logout_verify_bid(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_logout_verify_bid(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         Assert.true(home_page.header.is_logout_menu_item_present)
         home_page.logout_using_url()
@@ -33,10 +33,9 @@ class TestAccount:
         home_page.wait_for_user_login()
         Assert.true(home_page.is_browserid_link_present)
 
-    @pytest.mark.skip_selenium
     @pytest.mark.nondestructive
-    def test_that_links_in_footer_return_200_code(self, mozwebqa):
-        crawler = LinkCrawler(mozwebqa)
+    def test_that_links_in_footer_return_200_code(self, base_url):
+        crawler = LinkCrawler(base_url)
         urls = crawler.collect_links('/', name='footer')
         bad_urls = []
 

--- a/tests/test_invite.py
+++ b/tests/test_invite.py
@@ -13,16 +13,16 @@ from pages.home_page import Home
 class TestInvite:
 
     @pytest.mark.credentials
-    def test_inviting_an_invalid_email_address(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_inviting_an_invalid_email_address(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         invite_page = home_page.header.click_invite_menu_item()
         invite_page.invite("invalidmail")
         Assert.equal('Enter a valid email address.', invite_page.error_text_message)
 
     @pytest.mark.credentials
-    def test_invite(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_invite(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         invite_page = home_page.header.click_invite_menu_item()
         email_address = "user@example.com"

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -17,8 +17,8 @@ class TestProfile:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_profile_deletion_confirmation(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_profile_deletion_confirmation(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         edit_profile_page = home_page.header.click_edit_profile_menu_item()
         confirm_profile_delete_page = edit_profile_page.click_delete_profile_button()
@@ -27,8 +27,8 @@ class TestProfile:
         Assert.true(confirm_profile_delete_page.is_delete_button_present)
 
     @pytest.mark.credentials
-    def test_edit_profile_information(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_edit_profile_information(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         profile_page = home_page.header.click_view_profile_menu_item()
         edit_profile_page = home_page.header.click_edit_profile_menu_item()
@@ -56,8 +56,8 @@ class TestProfile:
         Assert.equal(website, new_website)
 
     @pytest.mark.credentials
-    def test_skill_addition(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_skill_addition(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
 
         edit_profile_page = home_page.header.click_edit_profile_menu_item()
@@ -69,8 +69,8 @@ class TestProfile:
         Assert.greater(skills.find("hello world"), -1, "Skill 'hello world' not added to profile.")
 
     @pytest.mark.credentials
-    def test_skill_deletion(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_skill_deletion(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
 
         edit_profile_page = home_page.header.click_edit_profile_menu_item()
@@ -86,8 +86,8 @@ class TestProfile:
             skills = profile_page.skills
             Assert.equal(skills.find("hello world"), -1, "Skill 'hello world' not deleted.")
 
-    def test_creating_profile_without_checking_privacy_policy_checkbox(self, mozwebqa, new_user):
-        home_page = Home(mozwebqa)
+    def test_creating_profile_without_checking_privacy_policy_checkbox(self, base_url, selenium, new_user):
+        home_page = Home(base_url, selenium)
         profile = home_page.create_new_user(new_user['email'], new_user['password'])
 
         profile.set_full_name("User that doesn't like policy")
@@ -104,8 +104,8 @@ class TestProfile:
 
         Assert.equal('Please correct the errors below.', profile.error_message)
 
-    def test_profile_creation(self, mozwebqa, new_user):
-        home_page = Home(mozwebqa)
+    def test_profile_creation(self, base_url, selenium, new_user):
+        home_page = Home(base_url, selenium)
         profile = home_page.create_new_user(new_user['email'], new_user['password'])
 
         profile.set_full_name("New MozilliansUser")
@@ -134,8 +134,8 @@ class TestProfile:
         Assert.equal('Mountain View, California, United States', profile_page.location)
 
     @pytest.mark.xfail(reason="Bug 835318 - Error adding groups / skills / or languages with non-latin chars.")
-    def test_non_ascii_characters_are_allowed_in_profile_information(self, mozwebqa, new_user):
-        home_page = Home(mozwebqa)
+    def test_non_ascii_characters_are_allowed_in_profile_information(self, base_url, selenium, new_user):
+        home_page = Home(base_url, selenium)
         profile = home_page.create_new_user(new_user['email'], new_user['password'])
 
         profile.set_full_name("New MozilliansUser")
@@ -164,8 +164,8 @@ class TestProfile:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_that_filter_by_city_works(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_that_filter_by_city_works(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
 
         profile_page = home_page.open_user_profile(u'Mozillians.User')
@@ -190,8 +190,8 @@ class TestProfile:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_that_filter_by_region_works(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_that_filter_by_region_works(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
 
         profile_page = home_page.open_user_profile(u'Mozillians.User')
@@ -215,8 +215,8 @@ class TestProfile:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_that_filter_by_country_works(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_that_filter_by_country_works(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
 
         profile_page = home_page.open_user_profile(u'Mozillians.User')
@@ -238,8 +238,8 @@ class TestProfile:
             u'Expected country: %s, but got: %s' % (country, random_profile_country))
 
     @pytest.mark.credentials
-    def test_that_non_us_user_can_set_get_involved_date(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_that_non_us_user_can_set_get_involved_date(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         edit_page = home_page.go_to_localized_edit_profile_page("es")
         selected_date = edit_page.month + edit_page.year
@@ -251,11 +251,10 @@ class TestProfile:
         Assert.not_equal(selected_date, edit_page.month + edit_page.year, "The date is not changed")
 
     @pytest.mark.credentials
-    def test_that_user_can_create_and_delete_group(self, mozwebqa, vouched_user):
-        current_time = time.strftime("%x" + "-" + "%X")
-        group_name = ('qa_test' + ' ' + current_time)
+    def test_that_user_can_create_and_delete_group(self, base_url, selenium, vouched_user):
+        group_name = (time.strftime('%x-%X'))
 
-        home_page = Home(mozwebqa)
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         edit_page = home_page.header.click_edit_profile_menu_item()
         groups = edit_page.click_find_group_link()
@@ -277,11 +276,11 @@ class TestProfile:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_private_groups_field_as_public_when_logged_in(self, mozwebqa, private_user):
+    def test_private_groups_field_as_public_when_logged_in(self, base_url, selenium, private_user):
         # User has certain fields preset to values to run the test properly
         # groups - private
         # belongs to at least one group
-        home_page = Home(mozwebqa)
+        home_page = Home(base_url, selenium)
         home_page.login(private_user['email'], private_user['password'])
 
         profile_page = home_page.header.click_view_profile_menu_item()
@@ -292,8 +291,8 @@ class TestProfile:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_private_groups_field_when_not_logged_in(self, mozwebqa, private_user):
-        home_page = Home(mozwebqa)
+    def test_private_groups_field_when_not_logged_in(self, base_url, selenium, private_user):
+        home_page = Home(base_url, selenium)
         profile_page = home_page.open_user_profile(private_user['name'])
 
         Assert.false(profile_page.is_groups_present,
@@ -301,12 +300,12 @@ class TestProfile:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_that_links_in_the_services_page_return_200_code(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_that_links_in_the_services_page_return_200_code(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
 
         edit_profile_page = home_page.header.click_edit_profile_menu_item()
-        crawler = LinkCrawler(mozwebqa)
+        crawler = LinkCrawler(base_url)
         urls = edit_profile_page.get_services_urls()
         bad_urls = []
 

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -9,11 +9,10 @@ import requests
 from unittestzero import Assert
 
 
-@pytest.mark.skip_selenium
 class TestRedirects:
 
     @pytest.mark.nondestructive
-    def test_302_redirect_for_anonymous_users(self, mozwebqa):
+    def test_302_redirect_for_anonymous_users(self, base_url):
         paths = ['/es/country/us/',
                  '/sq/country/doesnotexist/',
                  '/hu/country/us/region/California/',
@@ -27,15 +26,15 @@ class TestRedirects:
                  '/lt/user/edit/',
                  '/en-US/invite/',
                  '/fr/register/']
-        urls = self.make_absolute_paths(mozwebqa.base_url, paths)
+        urls = self.make_absolute_paths(base_url, paths)
         error_list = self.verify_http_response_codes(urls, 302)
 
         Assert.equal(0, len(error_list), error_list)
 
     @pytest.mark.nondestructive
-    def test_200_for_anonymous_users(self, mozwebqa):
+    def test_200_for_anonymous_users(self, base_url):
         paths = ['/pl/opensearch.xml', '/nl/u/Mozillians.User/']
-        urls = self.make_absolute_paths(mozwebqa.base_url, paths)
+        urls = self.make_absolute_paths(base_url, paths)
         error_list = self.verify_http_response_codes(urls, 200)
 
         Assert.equal(len(error_list), 0, error_list)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -18,17 +18,17 @@ class TestSearch:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_that_search_returns_results_for_email_substring(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_that_search_returns_results_for_email_substring(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         search_page = home_page.header.search_for(u'@mozilla.com')
         Assert.true(search_page.results_count > 0)
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_that_search_returns_results_for_first_name(self, mozwebqa, vouched_user):
+    def test_that_search_returns_results_for_first_name(self, base_url, selenium, vouched_user):
         query = u'Matt'
-        home_page = Home(mozwebqa)
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         search_page = home_page.header.search_for(query)
         Assert.true(search_page.results_count > 0)
@@ -39,41 +39,41 @@ class TestSearch:
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_that_search_returns_results_for_irc_nickname(self, mozwebqa, vouched_user):
-        home_page = Home(mozwebqa)
+    def test_that_search_returns_results_for_irc_nickname(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         home_page.header.search_for(u'mbrandt')
-        profile = Profile(mozwebqa)
+        profile = Profile(base_url, selenium)
         Assert.equal(u'Matt Brandt', profile.name)
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
-    def test_search_for_not_existing_mozillian_when_logged_in(self, mozwebqa, vouched_user):
+    def test_search_for_not_existing_mozillian_when_logged_in(self, base_url, selenium, vouched_user):
         query = u'Qwerty'
-        home_page = Home(mozwebqa)
+        home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
         search_page = home_page.header.search_for(query)
         Assert.equal(search_page.results_count, 0)
 
     @pytest.mark.nondestructive
-    def test_search_for_not_existing_mozillian_when_not_logged_in(self, mozwebqa):
+    def test_search_for_not_existing_mozillian_when_not_logged_in(self, base_url, selenium):
         query = u'Qwerty'
-        home_page = Home(mozwebqa)
+        home_page = Home(base_url, selenium)
         search_page = home_page.header.search_for(query)
         Assert.equal(search_page.results_count, 0)
 
     @pytest.mark.nondestructive
-    def test_search_for_empty_string_redirects_to_search_page(self, mozwebqa):
+    def test_search_for_empty_string_redirects_to_search_page(self, base_url, selenium):
         # Searching for empty string redirects to the Search page
         # with publicly available profiles
         query = u''
-        home_page = Home(mozwebqa)
+        home_page = Home(base_url, selenium)
         search_page = home_page.header.search_for(query)
         Assert.true(search_page.results_count > 0)
 
     @pytest.mark.xfail(reason="bug 977424 - API count and actual count do not return the same values")
     @pytest.mark.nondestructive
-    def test_vouched_user_count(self, mozwebqa, variables):
+    def test_vouched_user_count(self, base_url, selenium, variables):
         r = requests.get('https://mozillians-dev.allizom.org/api/v1/users/', params={
             'app_name': variables['api']['application'],
             'app_key': variables['api']['key'],
@@ -85,7 +85,7 @@ class TestSearch:
         r = r.json()
 
         api_count = r['meta'].get('total_count')
-        home_page = Home(mozwebqa)
+        home_page = Home(base_url, selenium)
         search_results = home_page.header.search_for('')
         results_on_page = search_results.results_count
         number_of_pages = int(search_results.number_of_pages)


### PR DESCRIPTION
I picked up on the initial work by @justinpotts to migrate to the new version of our pytest plugin.

Pinging @m8ttyB and @johngian for review.

Adhoc jobs:
* [Sauce Labs](http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/mozillians.adhoc.pytest-selenium/4/)
* [Grid (Windows)](http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/mozillians.adhoc.pytest-selenium/6/)
* [Grid (OSX)](http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/mozillians.adhoc.pytest-selenium/8/)