### PR TITLE
Fix tests for new profile edit UI

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -87,6 +87,7 @@ class Base(Page):
     class Header(Page):
 
         _search_box_locator = (By.CSS_SELECTOR, '.search-query')
+        _search_box_loggedin_locator = (By.CSS_SELECTOR, '.search-right > form > .search-query')
         _profile_menu_locator = (By.CSS_SELECTOR, '#nav-main > a.dropdown-toggle')
 
         # menu items
@@ -100,8 +101,11 @@ class Base(Page):
         def is_search_box_present(self):
             return self.is_element_present(*self._search_box_locator)
 
-        def search_for(self, search_term):
-            search_field = self.selenium.find_element(*self._search_box_locator)
+        def search_for(self, search_term, loggedin=False):
+            if loggedin:
+                search_field = self.selenium.find_element(*self._search_box_loggedin_locator)
+            else:
+                search_field = self.selenium.find_element(*self._search_box_locator)
             search_field.send_keys(search_term)
             search_field.send_keys(Keys.RETURN)
             from pages.search import Search

--- a/pages/base.py
+++ b/pages/base.py
@@ -93,7 +93,7 @@ class Base(Page):
         _dropdown_menu_locator = (By.CSS_SELECTOR, 'ul.dropdown-menu')
         _view_profile_menu_item_locator = (By.ID, 'nav-profile')
         _invite_menu_item_locator = (By.ID, 'nav-invite')
-        _edit_profile_menu_item_locator = (By.ID, 'nav-edit-profile')
+        _settings_menu_item_locator = (By.ID, 'nav-edit-profile')
         _logout_menu_item_locator = (By.ID, 'nav-logout')
 
         @property
@@ -128,11 +128,11 @@ class Base(Page):
             from pages.invite import Invite
             return Invite(self.base_url, self.selenium)
 
-        def click_edit_profile_menu_item(self):
+        def click_settings_menu_item(self):
             self.click_options()
-            self.selenium.find_element(*self._edit_profile_menu_item_locator).click()
-            from pages.edit_profile import EditProfile
-            return EditProfile(self.base_url, self.selenium)
+            self.selenium.find_element(*self._settings_menu_item_locator).click()
+            from pages.settings import Settings
+            return Settings(self.base_url, self.selenium)
 
         def click_logout_menu_item(self):
             self.click_options()

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -15,10 +15,10 @@ class Home(Base):
         if open_url:
             self.selenium.get(self.base_url)
 
-    def go_to_localized_edit_profile_page(self, non_US):
+    def go_to_localized_settings_page(self, non_US):
         self.get_relative_path("/" + non_US + "/user/edit/")
-        from pages.edit_profile import EditProfile
-        return EditProfile(self.base_url, self.selenium)
+        from pages.settings import Settings
+        return Settings(self.base_url, self.selenium)
 
     def wait_for_user_login(self):
         # waits to see if user gets logged back in

--- a/pages/register.py
+++ b/pages/register.py
@@ -17,16 +17,11 @@ class Register(Base):
 
     _error_locator = (By.CSS_SELECTOR, 'div.alert.alert-error')
     _full_name_field_locator = (By.ID, 'id_full_name')
-    _website_field_locator = (By.ID, 'id_website')
-    _bio_field_locator = (By.ID, 'id_bio')
-    _skills_field_locator = (By.CSS_SELECTOR, '#id_skills + ul input')
-    _language_locator = (By.ID, 'id_language_set-0-code')
-    _previous_button_locator = (By.ID, 'page1button')
     _map_search_box_locator = (By.ID, 'location_search')
     _country_locator = (By.ID, 'display_country')
     _privacy_locator = (By.ID, 'id_optin')
     _privacy_error_message_locator = (By.CSS_SELECTOR, '.error-message')
-    _create_profile_button_locator = (By.CSS_SELECTOR, '#edit-controls > button')
+    _create_profile_button_locator = (By.CSS_SELECTOR, '#form-submit-top')
 
     @property
     def error_message(self):
@@ -42,28 +37,6 @@ class Register(Base):
     def set_full_name(self, full_name):
         element = self.selenium.find_element(*self._full_name_field_locator)
         element.send_keys(full_name)
-
-    def set_website(self, website):
-        element = self.selenium.find_element(*self._website_field_locator)
-        element.send_keys(website)
-
-    def set_bio(self, biography):
-        element = self.selenium.find_element(*self._bio_field_locator)
-        element.send_keys(biography)
-
-    def select_language(self, language):
-        element = self.selenium.find_element(*self._language_locator)
-        select = Select(element)
-        select.select_by_value(language)
-
-    def add_skill(self, skill_name):
-        element = self.selenium.find_element(*self._skills_field_locator)
-        element.send_keys(skill_name)
-        # send tab to make the entry "stick"
-        element.send_keys("\t")
-
-    def click_previous_button(self):
-        self.selenium.find_element(*self._previous_button_locator).click()
 
     @property
     def privacy_error_message(self):

--- a/pages/search.py
+++ b/pages/search.py
@@ -13,7 +13,7 @@ from pages.page import PageRegion
 
 class Search(Base):
 
-    _result_locator = (By.CSS_SELECTOR, 'div.row > div.result')
+    _result_locator = (By.CSS_SELECTOR, '#content-wrapper > #main > div.row > div.result')
     _search_button_locator = (By.CSS_SELECTOR, '.btn.primary:nth-of-type(1)')
     _advanced_options_button_locator = (By.CSS_SELECTOR, '.btn.primary:nth-of-type(2)')
     _advanced_options_locator = (By.CSS_SELECTOR, '.search-options')

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import random
+
+from pages.base import Base
+from pages.page import PageRegion
+
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
+
+
+class Settings(Base):
+    _profile_tab_locator = (By.ID, 'profile-tab')
+    _profile_button_locator = (By.CSS_SELECTOR, '#profile-li > a')
+
+    _you_and_mozilla_tab_locator = (By.ID, 'youandmozilla-tab')
+    _you_and_mozilla_button_locator = (By.CSS_SELECTOR, '#youandmozilla-li > a')
+
+    _developer_tab_locator = (By.ID, 'developer-tab')
+    _developer_button_locator = (By.CSS_SELECTOR, '#developer-li > a')
+
+    @property
+    def profile(self):
+        self.selenium.find_element(*self._profile_button_locator).click()
+        return self.ProfileTab(self.base_url, self.selenium,
+                               self.selenium.find_element(*self._profile_tab_locator))
+
+    @property
+    def you_and_mozilla(self):
+        self.selenium.find_element(*self._you_and_mozilla_button_locator).click()
+        return self.YouAndMozilla(self.base_url, self.selenium,
+                                  self.selenium.find_element(*self._you_and_mozilla_tab_locator))
+
+    @property
+    def developer(self):
+        self.selenium.find_element(*self._developer_button_locator).click()
+        return self.DeveloperTab(self.base_url, self.selenium,
+                                 self.selenium.find_element(*self._developer_tab_locator))
+
+    class ProfileTab(PageRegion):
+        _basic_info_form_locator = (By.CSS_SELECTOR, 'form.edit-profile:nth-child(1)')
+        _skills_form_locator = (By.CSS_SELECTOR, 'form.edit-profile:nth-child(3)')
+        _delete_account_form_locator = (By.CSS_SELECTOR, 'div.panel-danger')
+
+        @property
+        def basic_information(self):
+            return self.EditProfileForm(self.base_url, self.selenium,
+                                        self._root_element.find_element(*self._basic_info_form_locator))
+
+        @property
+        def skills(self):
+            return self.SkillsForm(self.base_url, self.selenium,
+                                   self._root_element.find_element(*self._skills_form_locator))
+
+        @property
+        def delete_account(self):
+            return self.DeleteAccount(self.base_url, self.selenium,
+                                      self._root_element.find_element(*self._delete_account_form_locator))
+
+        class EditProfileForm (PageRegion):
+
+            _full_name_field_locator = (By.ID, 'id_full_name')
+            _bio_field_locator = (By.ID, 'id_bio')
+            _update_locator = (By.ID, 'form-submit-top')
+
+            def set_full_name(self, full_name):
+                element = self._root_element.find_element(*self._full_name_field_locator)
+                element.clear()
+                element.send_keys(full_name)
+
+            def set_bio(self, biography):
+                element = self._root_element.find_element(*self._bio_field_locator)
+                element.clear()
+                element.send_keys(biography)
+
+            def click_update(self):
+                self._root_element.find_element(*self._update_locator).click()
+
+        class DeleteAccount(PageRegion):
+
+            _delete_acknowledgement_locator = (By.CSS_SELECTOR, '#delete>input')
+            _delete_profile_button_locator = (By.ID, 'delete-profile')
+
+            def check_acknowledgement(self):
+                self._root_element.find_element(*self._delete_acknowledgement_locator).click()
+
+            @property
+            def is_delete_button_enabled(self):
+                return 'disabled' not in self._root_element.find_element(*self._delete_profile_button_locator).get_attribute('class')
+
+            def click_delete_profile(self):
+                self._root_element.find_element(*self._delete_profile_button_locator).click()
+                from pages.confirm_profile_delete import ConfirmProfileDelete
+                return ConfirmProfileDelete(self.base_url, self.selenium)
+
+        class SkillsForm(PageRegion):
+            _skills_locator = (By.CSS_SELECTOR, '#skills .tagit-label')
+            _skills_field_locator = (By.CSS_SELECTOR, '#id_skills + ul input')
+            _delete_skill_buttons_locator = (By.CSS_SELECTOR, '#skills .tagit-close')
+            _update_locator = (By.ID, 'form-submit-top')
+
+            @property
+            def skills(self):
+                skills = self._root_element.find_elements(*self._skills_locator)
+                return [skills[i].text for i in range(0, len(skills))]
+
+            def add_skill(self, skill_name):
+                element = self._root_element.find_element(*self._skills_field_locator)
+                element.send_keys(skill_name)
+                element.send_keys(Keys.RETURN)
+
+            @property
+            def delete_skill_buttons(self):
+                return self._root_element.find_elements(*self._delete_skill_buttons_locator)
+
+            def click_update(self):
+                self._root_element.find_element(*self._update_locator).click()
+
+    class YouAndMozilla(PageRegion):
+
+        _contributions_form_locator = (By.CSS_SELECTOR, 'form.edit-profile:nth-child(1)')
+
+        @property
+        def contributions(self):
+            return self.Contributions(self.base_url, self.selenium,
+                                      self._root_element.find_element(*self._contributions_form_locator))
+
+        class Contributions(PageRegion):
+
+            _select_month_locator = (By.ID, 'id_date_mozillian_month')
+            _select_year_locator = (By.ID, 'id_date_mozillian_year')
+            _month_locator = (By.CSS_SELECTOR, '#id_date_mozillian_month > option')
+            _year_locator = (By.CSS_SELECTOR, '#id_date_mozillian_year > option')
+            _selected_month_locator = (By.CSS_SELECTOR, '#id_date_mozillian_month > option[selected="selected"]')
+            _selected_year_locator = (By.CSS_SELECTOR, '#id_date_mozillian_year > option[selected="selected"]')
+            _update_locator = (By.ID, 'form-submit-top')
+
+            def select_month(self, option_month):
+                element = self._root_element.find_element(*self._select_month_locator)
+                select = Select(element)
+                select.select_by_value(option_month)
+
+            def select_year(self, option_year):
+                element = self._root_element.find_element(*self._select_year_locator)
+                select = Select(element)
+                select.select_by_value(option_year)
+
+            @property
+            def month(self):
+                # Return selected month text
+                return self._root_element.find_element(*self._selected_month_locator).text
+
+            @property
+            def year(self):
+                # Return selected year text
+                return self._root_element.find_element(*self._selected_year_locator).text
+
+            @property
+            def months_values(self):
+                # Return all month values
+                return [month.get_attribute('value') for month in self._root_element.find_elements(*self._month_locator)]
+
+            @property
+            def years_values(self):
+                # Return all year values
+                return [year.get_attribute('value') for year in self._root_element.find_elements(*self._year_locator)]
+
+            def select_random_month(self):
+                return self.select_month(random.choice(self.months_values[1:]))
+
+            def select_random_year(self):
+                return self.select_year(random.choice(self.years_values[1:]))
+
+            def click_update(self):
+                self._root_element.find_element(*self._update_locator).click()
+
+    class DeveloperTab(PageRegion):
+
+        _services_bugzilla_locator = (By.ID, 'services-bugzilla-url')
+        _services_mozilla_reps_locator = (By.ID, 'services-mozilla-reps')
+
+        def get_services_urls(self):
+            locs = [self._services_bugzilla_locator, self._services_mozilla_reps_locator]
+            urls = []
+
+            for element in locs:
+                url = self._root_element.find_element(*element).get_attribute('href')
+                urls.append(url)
+
+            return urls

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -8,6 +8,7 @@ import random
 
 from pages.base import Base
 from pages.page import PageRegion
+from pages.groups_page import GroupsPage
 
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
@@ -20,6 +21,9 @@ class Settings(Base):
 
     _you_and_mozilla_tab_locator = (By.ID, 'youandmozilla-tab')
     _you_and_mozilla_button_locator = (By.CSS_SELECTOR, '#youandmozilla-li > a')
+
+    _groups_tab_locator = (By.ID, 'mygroups-tab')
+    _groups_button_locator = (By.CSS_SELECTOR, '#mygroups-li > a')
 
     _developer_tab_locator = (By.ID, 'developer-tab')
     _developer_button_locator = (By.CSS_SELECTOR, '#developer-li > a')
@@ -35,6 +39,12 @@ class Settings(Base):
         self.selenium.find_element(*self._you_and_mozilla_button_locator).click()
         return self.YouAndMozilla(self.base_url, self.selenium,
                                   self.selenium.find_element(*self._you_and_mozilla_tab_locator))
+
+    @property
+    def groups(self):
+        self.selenium.find_element(*self._groups_button_locator).click()
+        return self.Groups(self.base_url, self.selenium,
+                           self.selenium.find_element(*self._groups_tab_locator))
 
     @property
     def developer(self):
@@ -178,6 +188,14 @@ class Settings(Base):
 
             def click_update(self):
                 self._root_element.find_element(*self._update_locator).click()
+
+    class Groups(PageRegion):
+
+        _find_group_page = (By.PARTIAL_LINK_TEXT, 'find the group')
+
+        def click_find_group_link(self):
+            self.selenium.find_element(*self._find_group_page).click()
+            return GroupsPage(self.base_url, self.selenium)
 
     class DeveloperTab(PageRegion):
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -15,6 +15,10 @@ from pages.link_crawler import LinkCrawler
 
 class TestProfile:
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
+    @pytest.mark.xfail("'mozillians.org' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on production")
     @pytest.mark.credentials
     @pytest.mark.nondestructive
     def test_profile_deletion_confirmation(self, base_url, selenium, vouched_user):
@@ -35,6 +39,8 @@ class TestProfile:
         Assert.true(confirm_profile_delete_page.is_cancel_button_present)
         Assert.true(confirm_profile_delete_page.is_delete_button_present)
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
     @pytest.mark.credentials
     def test_edit_profile_information(self, base_url, selenium, vouched_user):
         home_page = Home(base_url, selenium)
@@ -62,6 +68,8 @@ class TestProfile:
         Assert.equal(name, new_full_name)
         Assert.equal(biography, new_biography)
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
     @pytest.mark.credentials
     def test_skill_addition(self, base_url, selenium, vouched_user):
         home_page = Home(base_url, selenium)
@@ -78,6 +86,8 @@ class TestProfile:
         skills = profile_page.skills
         Assert.greater(skills.find("hello world"), -1, "Skill 'hello world' not added to profile.")
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
     @pytest.mark.credentials
     def test_skill_deletion(self, base_url, selenium, vouched_user):
         home_page = Home(base_url, selenium)
@@ -101,81 +111,6 @@ class TestProfile:
         if profile_page.is_skills_present:
             skills = profile_page.skills
             Assert.equal(skills.find("hello world"), -1, "Skill 'hello world' not deleted.")
-
-    def test_creating_profile_without_checking_privacy_policy_checkbox(self, base_url, selenium, new_user):
-        home_page = Home(base_url, selenium)
-        profile = home_page.create_new_user(new_user['email'], new_user['password'])
-
-        profile.set_full_name("User that doesn't like policy")
-
-        # Skills
-        profile.add_skill('test')
-        profile.select_language('en')
-
-        # Location
-        profile.set_location('Durango, Colorado')
-
-        profile.click_create_profile_button()
-
-        Assert.equal('Please correct the errors below.', profile.error_message)
-
-    def test_profile_creation(self, base_url, selenium, new_user):
-        home_page = Home(base_url, selenium)
-        profile = home_page.create_new_user(new_user['email'], new_user['password'])
-
-        profile.set_full_name("New MozilliansUser")
-        profile.set_bio("Hello, I'm new here and trying stuff out. Oh, and by the way: I'm a robot, run in a cronjob, most likely")
-
-        # Skills
-        profile.add_skill('test')
-        profile.select_language('en')
-
-        # Location
-        profile.set_location('Mountain View, 94041, California')
-
-        # agreed to privacy policy
-        profile.check_privacy()
-
-        profile_page = profile.click_create_profile_button()
-
-        Assert.true(profile_page.was_account_created_successfully)
-        Assert.true(profile_page.is_pending_approval_visible)
-
-        Assert.equal('New MozilliansUser', profile_page.name)
-        Assert.equal(new_user['email'], profile_page.email)
-        Assert.equal("Hello, I'm new here and trying stuff out. Oh, and by the way: I'm a robot, run in a cronjob, most likely", profile_page.biography)
-        Assert.equal('test', profile_page.skills)
-        Assert.equal('English', profile_page.languages)
-        Assert.equal('Mountain View, California, United States', profile_page.location)
-
-    @pytest.mark.xfail(reason="Bug 835318 - Error adding groups / skills / or languages with non-latin chars.")
-    def test_non_ascii_characters_are_allowed_in_profile_information(self, base_url, selenium, new_user):
-        home_page = Home(base_url, selenium)
-        profile = home_page.create_new_user(new_user['email'], new_user['password'])
-
-        profile.set_full_name("New MozilliansUser")
-        profile.set_bio("Hello, I'm new here and trying stuff out. Oh, and by the way: I'm a robot, run in a cronjob, most likely")
-
-        # Skills
-        profile.add_skill(u'\u0394\u03D4\u03D5\u03D7\u03C7\u03C9\u03CA\u03E2')
-
-        # Location
-        profile.set_location('Athens, Greece')
-
-        # agreed to privacy policy
-        profile.check_privacy()
-
-        profile_page = profile.click_create_profile_button()
-
-        Assert.true(profile_page.was_account_created_successfully)
-        Assert.true(profile_page.is_pending_approval_visible)
-
-        Assert.equal('New MozilliansUser', profile_page.name)
-        Assert.equal(new_user['email'], profile_page.email)
-        Assert.equal("Hello, I'm new here and trying stuff out. Oh, and by the way: I'm a robot, run in a cronjob, most likely", profile_page.biography)
-        Assert.equal(u'\u0394\u03D4\u03D5\u03D7\u03C7\u03C9\u03CA\u03E2', profile_page.skills)
-        Assert.equal(u'\u0394\u03D4\u03D5\u03D7\u03C7\u03C9\u03CA\u03E2', profile_page.languages)
-        Assert.equal('Athenes, Greece, Greece', profile_page.location)
 
     @pytest.mark.credentials
     @pytest.mark.nondestructive
@@ -252,6 +187,8 @@ class TestProfile:
             country, random_profile_country,
             u'Expected country: %s, but got: %s' % (country, random_profile_country))
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
     @pytest.mark.credentials
     def test_that_non_us_user_can_set_get_involved_date(self, base_url, selenium, vouched_user):
         home_page = Home(base_url, selenium)
@@ -271,6 +208,8 @@ class TestProfile:
 
         Assert.not_equal(selected_date, contributions.month + contributions.year, "The date is not changed")
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
     @pytest.mark.credentials
     def test_that_user_can_create_and_delete_group(self, base_url, selenium, vouched_user):
         group_name = (time.strftime('%x-%X'))
@@ -319,6 +258,10 @@ class TestProfile:
         Assert.false(profile_page.is_groups_present,
                      u'Profile: ' + profile_page.get_url_current_page())
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
+    @pytest.mark.xfail("'mozillians.org' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on production")
     @pytest.mark.credentials
     @pytest.mark.nondestructive
     def test_that_links_in_the_services_page_return_200_code(self, base_url, selenium, vouched_user):

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -277,8 +277,8 @@ class TestProfile:
 
         home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
-        edit_page = home_page.header.click_settings_menu_item()
-        groups = edit_page.click_find_group_link()
+        settings = home_page.header.click_settings_menu_item()
+        groups = settings.groups.click_find_group_link()
         create_group = groups.click_create_group_main_button()
         create_group.create_group_name(group_name)
         create_group.click_create_group_submit()

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from unittestzero import Assert
+from pages.home_page import Home
+
+
+class TestRegister:
+
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
+    def test_profile_creation(self, base_url, selenium, new_user):
+        home_page = Home(base_url, selenium)
+        profile = home_page.create_new_user(new_user['email'], new_user['password'])
+
+        profile.set_full_name("New MozilliansUser")
+
+        # Location
+        profile.set_location('Mountain View, 94041, California')
+
+        # agreed to privacy policy
+        profile.check_privacy()
+
+        profile_page = profile.click_create_profile_button()
+
+        Assert.true(profile_page.was_account_created_successfully)
+        Assert.true(profile_page.is_pending_approval_visible)
+
+        Assert.equal('New MozilliansUser', profile_page.name)
+        Assert.equal(new_user['email'], profile_page.email)
+        Assert.equal('Mountain View, California, United States', profile_page.location)
+
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - Registration UI redesign not yet deployed on stage")
+    def test_creating_profile_without_checking_privacy_policy_checkbox(self, base_url, selenium, new_user):
+        home_page = Home(base_url, selenium)
+        profile = home_page.create_new_user(new_user['email'], new_user['password'])
+
+        profile.set_full_name("User that doesn't like policy")
+
+        # Location
+        profile.set_location('Durango, Colorado')
+
+        profile.click_create_profile_button()
+
+        Assert.equal('Please correct the errors below.', profile.error_message)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -16,43 +16,61 @@ from pages.profile import Profile
 
 class TestSearch:
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - UI redesign not yet deployed on stage")
+    @pytest.mark.xfail("'mozillians.org' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - UI redesign not yet deployed on production")
+    @pytest.mark.xfail("'mozillians-dev' in config.getvalue('base_url')",
+                       reason="Bug 944101 - Searching by email substring does not return all results")
     @pytest.mark.credentials
     @pytest.mark.nondestructive
     def test_that_search_returns_results_for_email_substring(self, base_url, selenium, vouched_user):
         home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
-        search_page = home_page.header.search_for(u'@mozilla.com')
+        search_page = home_page.header.search_for(u'@mozilla.com', loggedin=True)
         Assert.true(search_page.results_count > 0)
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - UI redesign not yet deployed on stage")
+    @pytest.mark.xfail("'mozillians.org' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - UI redesign not yet deployed on production")
     @pytest.mark.credentials
     @pytest.mark.nondestructive
     def test_that_search_returns_results_for_first_name(self, base_url, selenium, vouched_user):
         query = u'Matt'
         home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
-        search_page = home_page.header.search_for(query)
+        search_page = home_page.header.search_for(query, loggedin=True)
         Assert.true(search_page.results_count > 0)
         # get random index
         random_profile = randrange(search_page.results_count)
         profile_name = search_page.search_results[random_profile].name
         Assert.contains(query, profile_name)
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - UI redesign not yet deployed on stage")
+    @pytest.mark.xfail("'mozillians.org' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - UI redesign not yet deployed on production")
     @pytest.mark.credentials
     @pytest.mark.nondestructive
     def test_that_search_returns_results_for_irc_nickname(self, base_url, selenium, vouched_user):
         home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
-        home_page.header.search_for(u'mbrandt')
+        home_page.header.search_for(u'mbrandt', loggedin=True)
         profile = Profile(base_url, selenium)
         Assert.equal(u'Matt Brandt', profile.name)
 
+    @pytest.mark.xfail("'mozillians.allizom' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - UI redesign not yet deployed on stage")
+    @pytest.mark.xfail("'mozillians.org' in config.getvalue('base_url')",
+                       reason="Bug 1129848 - UI redesign not yet deployed on production")
     @pytest.mark.credentials
     @pytest.mark.nondestructive
     def test_search_for_not_existing_mozillian_when_logged_in(self, base_url, selenium, vouched_user):
         query = u'Qwerty'
         home_page = Home(base_url, selenium)
         home_page.login(vouched_user['email'], vouched_user['password'])
-        search_page = home_page.header.search_for(query)
+        search_page = home_page.header.search_for(query, loggedin=True)
         Assert.equal(search_page.results_count, 0)
 
     @pytest.mark.nondestructive


### PR DESCRIPTION
Worked on top of @bebef1987 commit. Fixed some minor issues and registration tests.

Ideally we should have more tests for the Settings page, to cover all tabs and subforms, but it's a good start. We may also need some further clean up for methods that are no longer needed for the UI, but these call happen in another PR.

All tests pass locally.