### PR TITLE
Test external accounts (issue 165)

### DIFF
--- a/pages/profile.py
+++ b/pages/profile.py
@@ -17,6 +17,7 @@ class Profile(Base):
     _profile_photo_locator = (By.CSS_SELECTOR, '.profile-photo img')
     _name_locator = (By.CSS_SELECTOR, 'h1.p-name')
     _email_locator = (By.CSS_SELECTOR, '.email')
+    _irc_nickname_locator = (By.CSS_SELECTOR, '.nickname')
     _website_locator = (By.CSS_SELECTOR, '.url')
     _vouched_by_locator = (By.CSS_SELECTOR, '#profile-info .vouched')
     _biography_locator = (By.CSS_SELECTOR, '#bio > .note > p')
@@ -51,6 +52,10 @@ class Profile(Base):
     @property
     def email(self):
         return self.selenium.find_element(*self._email_locator).text
+
+    @property
+    def irc_nickname(self):
+        return self.selenium.find_element(*self._irc_nickname_locator).text
 
     @property
     def website(self):

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -25,6 +25,9 @@ class Settings(Base):
     _groups_tab_locator = (By.ID, 'mygroups-tab')
     _groups_button_locator = (By.CSS_SELECTOR, '#mygroups-li > a')
 
+    _external_accounts_tab_locator = (By.ID, 'extaccounts-tab')
+    _external_accounts_button_locator = (By.CSS_SELECTOR, '#extaccounts-li > a')
+
     _developer_tab_locator = (By.ID, 'developer-tab')
     _developer_button_locator = (By.CSS_SELECTOR, '#developer-li > a')
 
@@ -45,6 +48,12 @@ class Settings(Base):
         self.selenium.find_element(*self._groups_button_locator).click()
         return self.Groups(self.base_url, self.selenium,
                            self.selenium.find_element(*self._groups_tab_locator))
+
+    @property
+    def external_accounts(self):
+        self.selenium.find_element(*self._external_accounts_button_locator).click()
+        return self.ExternalAccountsTab(self.base_url, self.selenium,
+                                        self.selenium.find_element(*self._external_accounts_tab_locator))
 
     @property
     def developer(self):
@@ -199,6 +208,54 @@ class Settings(Base):
         def click_find_group_link(self):
             self.selenium.find_element(*self._find_group_page).click()
             return GroupsPage(self.base_url, self.selenium)
+
+    class ExternalAccountsTab(PageRegion):
+
+        _external_accounts_form_locator = (By.CSS_SELECTOR, '#extaccounts-tab > div:nth-child(1)')
+        _irc_form_locator = (By.CSS_SELECTOR, '#extaccounts-tab > div:nth-child(2)')
+
+        @property
+        def external_accounts_form(self):
+            return self.ExternalAccounts(self.base_url, self.selenium,
+                                         self._root_element.find_element(*self._external_accounts_form_locator))
+
+        @property
+        def irc_form(self):
+            return self.Irc(self.base_url, self.selenium, self._root_element.find_element(*self._irc_form_locator))
+
+        class ExternalAccounts(PageRegion):
+            _add_account_locator = (By.ID, 'accounts-addfield')
+            _account_row_locator = (By.CSS_SELECTOR, 'div.externalaccount-fieldrow')
+
+            @property
+            def is_displayed(self):
+                return self._root_element.is_displayed()
+
+            def count_external_accounts(self):
+                return len(self._root_element.find_elements(*self._account_row_locator))
+
+            def click_add_account(self):
+                self._root_element.find_element(*self._add_account_locator).click()
+
+        class Irc(PageRegion):
+            _irc_nickname_locator = (By.ID, 'id_ircname')
+            _update_locator = (By.ID, 'form-submit-irc')
+
+            @property
+            def nickname(self):
+                return self._root_element.find_element(*self._irc_nickname_locator).get_attribute('value')
+
+            @property
+            def is_displayed(self):
+                return self._root_element.is_displayed()
+
+            def update_nickname(self, new_nickname):
+                element = self._root_element.find_element(*self._irc_nickname_locator)
+                element.clear()
+                element.send_keys(new_nickname)
+
+            def click_update(self):
+                self._root_element.find_element(*self._update_locator).click()
 
     class DeveloperTab(PageRegion):
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -235,3 +235,48 @@ class TestProfile:
                 bad_urls.append(check_result)
 
         assert 0 == len(bad_urls), u'%s bad links found. ' % len(bad_urls) + ', '.join(bad_urls)
+
+    @pytest.mark.credentials
+    @pytest.mark.nondestructive
+    def test_that_user_can_view_external_accounts(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
+        home_page.login(vouched_user['email'], vouched_user['password'])
+        settings = home_page.header.click_settings_menu_item()
+
+        assert settings.external_accounts.irc_form.is_displayed
+        assert settings.external_accounts.external_accounts_form.is_displayed
+
+    @pytest.mark.credentials
+    def test_that_user_can_add_external_account(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
+        home_page.login(vouched_user['email'], vouched_user['password'])
+        settings = home_page.header.click_settings_menu_item()
+
+        external_accounts_form = settings.external_accounts.external_accounts_form
+        cnt_external_accounts = external_accounts_form.count_external_accounts()
+        external_accounts_form.click_add_account()
+        new_cnt_external_accounts = external_accounts_form.count_external_accounts()
+        assert (cnt_external_accounts + 1) == new_cnt_external_accounts
+
+    @pytest.mark.credentials
+    def test_that_user_can_modify_external_accounts_irc_nickname(self, base_url, selenium, vouched_user):
+        home_page = Home(base_url, selenium)
+        home_page.login(vouched_user['email'], vouched_user['password'])
+        settings = home_page.header.click_settings_menu_item()
+
+        irc_form = settings.external_accounts.irc_form
+        old_nickname = irc_form.nickname
+        new_nickname = old_nickname + '_'
+        irc_form.update_nickname(new_nickname)
+        irc_form.click_update()
+
+        profile_page = home_page.header.click_view_profile_menu_item()
+        assert new_nickname == profile_page.irc_nickname
+
+        settings = home_page.header.click_settings_menu_item()
+        irc_form = settings.external_accounts.irc_form
+        irc_form.update_nickname(old_nickname)
+        irc_form.click_update()
+
+        profile_page = home_page.header.click_view_profile_menu_item()
+        assert old_nickname == profile_page.irc_nickname


### PR DESCRIPTION
Tests for issue #165. I'm not sure how general/specific they should be. I created a basic one that doesn't change anything that simply verifies the external accounts and irc nickname forms exist. It's not really needed with the other two but I thought it'd be good to have a smoke test for prd (?). 

I can remove or modify the tests as desired. For example, test_that_user_can_add_external_account could actually add an account rather than just click the link to add a new row and a second test could delete it. Selecting the dropdown with a valid url/name is a bit more complicated than what I have now so I didn't want to get started on it if it's not wanted.