### PR TITLE
Revert pytest to 2.7.3 from 2.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest==2.9.0
+pytest==2.7.3
 pytest-selenium
 pytest-variables
 requests==2.9.1


### PR DESCRIPTION
For a reason I still don't understand, this fixes Jenkins runs:

http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/mozillians.adhoc/71/console:

<snip>
12:03:49 ==================== 28 passed, 2 xfailed in 133.28 seconds ====================

There are 3 py.test warnings which -- during the Execute Shell build-step in Jenkins -- seem to be fatal, with the previous version/config:

http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/mozillians.adhoc/72/console:

12:04:19 ============================ pytest-warning summary ============================
12:04:19 WI2 /var/lib/jenkins/jobs/mozillians.adhoc/workspace@2/.venv/lib/python2.7/site-packages/xdist/plugin.py:43 use pluginmanager.add_hookspecs instead of deprecated addhooks() method.
12:04:19 WI1 /var/lib/jenkins/jobs/mozillians.adhoc/workspace@2/.venv/lib/python2.7/site-packages/xdist/plugin.py:58 'pytest_configure' hook uses deprecated __multicall__ argument
12:04:19 WI9 None could not create cache path //.cache/v/cache/lastfailed
12:04:19 ========== 28 passed, 2 xfailed, 3 pytest-warnings in 133.19 seconds ===========
12:04:19 Build step 'Conditional step (single)' marked build as failure

Sorry that I didn't catch this before :-(