### PR TITLE
Ensure groups and functional areas are only visible to vouched users …

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ mozillians-tests but it does require a few skills.  You will need to be familiar
 with Python, Selenium, and have a working knowledge of GitHub.
 
 If you are comfortable with Python, it's worth having a look at the Selenium
-framework to understand the basic concepts of browser-based testing and the 
+framework to understand the basic concepts of browser-based testing and the
 page objects pattern.
 
 If you need to brush up on programming but are eager to start contributing
@@ -34,7 +34,7 @@ thrilled to have your help!
 To brush up on Python skills before engaging with us, [Dive Into Python][dive]
 is an excellent resource.  MIT also has [lecture notes on Python][mit] available
 through their open courseware.  The programming concepts you will need to know
-include functions, working with classes, and the basics of object-oriented 
+include functions, working with classes, and the basics of object-oriented
 programming.
 
 Questions are always welcome
@@ -70,12 +70,12 @@ Before you will be able to run these tests you will need to have
 [Python]: http://www.python.org/download/releases/2.6.8/
 
 ####Virtualenv and Virtualenvwrapper (Optional/Intermediate level)
-While most of us have had some experience using virtual machines, 
+While most of us have had some experience using virtual machines,
 [virtualenv][venv] is something else entirely.  It's used to keep libraries
 that you install from clashing and messing up your local environment.  After
 installing virtualenv, installing [virtualenvwrapper][wrapper] will give you
 some nice commands to use with virtualenvwrapper. [virtualenv][venv] will allow
-you to install Python modules and run your tests in a sandboxed environment. 
+you to install Python modules and run your tests in a sandboxed environment.
 
 __note__
 
@@ -104,14 +104,14 @@ If you are running on Ubuntu/Debian you will need to do following first
 to install the required Python libraries.
 
 #### Credentials
-Some of the tests in mozillians-tests require accounts for 
+Some of the tests in mozillians-tests require accounts for
 https://mozillians.allizom.org. You'll need to create three sets of credentials
 with varying privilege levels.
 
-1. Create two username and password combinations on https://mozillians.allizom.org
-2. Join #commtools and ask for these users to be vouched (or ask someone on #mozwebqa to do this for you)
-3. In one of these users profile, join at least one group and mark groups as private
-4. Copy mozillians-tests/variables.json to a location outside of mozillians-tests. Update the 'vouched' and 'private' users in variables.json with those credentials
+1. Create three username and password combinations on https://mozillians.allizom.org
+2. Join #commtools and ask for two of these users to be vouched (or ask someone on #mozwebqa to do this for you)
+3. In one of the vouched users' profiles, join at least one group and mark groups as private
+4. Copy mozillians-tests/variables.json to a location outside of mozillians-tests. Update the 'vouched', 'private', and 'unvouched' users in variables.json with those credentials
 
 #### Running tests locally
 Before each test run, clean up the repo:
@@ -123,19 +123,14 @@ Note: If you are running tests on a Mac, run:
 To run tests locally it is as simple as calling <code>py.test</code> with
 several flags. To run testcases that do not modify or delete data:
 
-    py.test --driver=firefox --baseurl=http://mozillians.allizom.org --variables=/full/path/to/variables.json .
-
-To run testcases that are known to change or delete account data use the
-<code>--destructive</code> flag:
-
-    py.test --driver=firefox --baseurl=http://mozillians.allizom.org --destructive --variables=/full/path/to/variables.json .
+    py.test --driver=Firefox --base-url=http://mozillians.allizom.org --variables=/full/path/to/variables.json .
 
 __Output__
 
 Output of a test run should look something like this:
 
     ============================= test session starts ==============================
-    collected 15 items 
+    collected 15 items
 
     tests/test_about_page.py ..
     tests/test_account.py ..

--- a/pages/base.py
+++ b/pages/base.py
@@ -93,6 +93,7 @@ class Base(Page):
         # menu items
         _dropdown_menu_locator = (By.CSS_SELECTOR, 'ul.dropdown-menu')
         _view_profile_menu_item_locator = (By.ID, 'nav-profile')
+        _groups_menu_item_locator = (By.ID, 'nav-groups')
         _invite_menu_item_locator = (By.ID, 'nav-invite')
         _settings_menu_item_locator = (By.ID, 'nav-edit-profile')
         _logout_menu_item_locator = (By.ID, 'nav-logout')
@@ -118,6 +119,10 @@ class Base(Page):
         @property
         def is_logout_menu_item_present(self):
             return self.is_element_present(*self._logout_menu_item_locator)
+
+        @property
+        def is_groups_menu_item_present(self):
+            return self.is_element_present(*self._groups_menu_item_locator)
 
         # menu items
         def click_view_profile_menu_item(self):

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -5,15 +5,27 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
 from pages.base import Base
 
 
 class Home(Base):
 
+    _groups_link_locator = (By.CSS_SELECTOR, 'section.groups > a')
+    _functional_areas_link_locator = (By.CSS_SELECTOR, 'section.functional-areas > a')
+
     def __init__(self, base_url, selenium, open_url=True):
         Base.__init__(self, base_url, selenium)
         if open_url:
             self.selenium.get(self.base_url)
+
+    @property
+    def is_groups_link_visible(self):
+        return self.is_element_visible(*self._groups_link_locator)
+
+    @property
+    def is_functional_areas_link_visible(self):
+        return self.is_element_visible(*self._functional_areas_link_locator)
 
     def go_to_localized_settings_page(self, non_US):
         self.get_relative_path("/" + non_US + "/user/edit/")

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -205,6 +205,10 @@ class Settings(Base):
 
         _find_group_page = (By.PARTIAL_LINK_TEXT, 'find the group')
 
+        @property
+        def is_find_group_link_visible(self):
+            return self.is_element_visible(*self._find_group_page)
+
         def click_find_group_link(self):
             self.selenium.find_element(*self._find_group_page).click()
             return GroupsPage(self.base_url, self.selenium)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,8 @@ def vouched_user(stored_users):
 @pytest.fixture
 def private_user(stored_users):
     return stored_users['private']
+
+
+@pytest.fixture
+def unvouched_user(stored_users):
+    return stored_users['unvouched']

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -280,3 +280,16 @@ class TestProfile:
 
         profile_page = home_page.header.click_view_profile_menu_item()
         assert old_nickname == profile_page.irc_nickname
+
+    @pytest.mark.credentials
+    @pytest.mark.nondestructive
+    def test_new_user_cannot_see_groups_or_functional_areas(self, base_url, selenium, unvouched_user):
+        home_page = Home(base_url, selenium)
+        home_page.login(unvouched_user['email'], unvouched_user['password'])
+
+        assert not home_page.header.is_groups_menu_item_present
+        assert not home_page.is_groups_link_visible
+        assert not home_page.is_functional_areas_link_visible
+
+        settings = home_page.header.click_settings_menu_item()
+        assert not settings.groups.is_find_group_link_visible


### PR DESCRIPTION
…(issue #187)

This has been reviewed in PR #209 but needs an unvouched user created in the test environments. The email/password webqabrowserid_unvouched@zoho.com/Password123 can be used. It should already exist in mozillians.allizom.org. This could be added to variables.json (instructions also in the README.md file):

    "unvouched": {
      "email": "webqabrowserid_unvouched@zoho.com",
      "password": "Password123",
      "name": "Mozilla.User"