### PR TITLE
Fix delete confirmation test

### DIFF
--- a/pages/settings.py
+++ b/pages/settings.py
@@ -102,7 +102,7 @@ class Settings(Base):
 
         class DeleteAccount(PageRegion):
 
-            _delete_acknowledgement_locator = (By.CSS_SELECTOR, '#delete>input')
+            _delete_acknowledgement_locator = (By.CSS_SELECTOR, '#delete-checkbox')
             _delete_profile_button_locator = (By.ID, 'delete-profile')
 
             def check_acknowledgement(self):


### PR DESCRIPTION
We [recently added](https://github.com/mozilla/mozillians/commit/746f2d79c66afef9fef9d0d17e70f8e028698c04) a label element to the delete confirmation checkbox. This broke the `test_profile_deletion_confirmation` test. This is a fix to get the right selector.