### PR TITLE
xfail stage & dev

### DIFF
--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -74,7 +74,7 @@ class TestGroup:
         assert group_type.is_member_criteria_visible
 
     @pytest.mark.credentials
-    @pytest.mark.xfail("'mozillians-dev.allizom.org' in config.getvalue('base_url')",
+    @pytest.mark.xfail("'allizom.org' in config.getvalue('base_url')",
                        reason='https://github.com/mozilla/mozillians-tests/issues/231')
     def test_group_invitations(self, base_url, selenium, vouched_user):
         home_page = Home(base_url, selenium)


### PR DESCRIPTION
Updating the xfail to include mozillians.allizom.org. The account under test has changed, see issue #231 for more information.