### PR TITLE
Remove obsolete API test

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -7,7 +7,6 @@
 from random import randrange
 
 import pytest
-import requests
 
 from pages.home_page import Home
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -71,25 +71,3 @@ class TestSearch:
         home_page = Home(base_url, selenium)
         search_page = home_page.header.search_for(query)
         assert search_page.results_count == 0
-
-    @pytest.mark.xfail(reason="bug 977424 - API count and actual count do not return the same values")
-    @pytest.mark.nondestructive
-    def test_vouched_user_count(self, base_url, selenium, variables):
-        r = requests.get('https://mozillians-dev.allizom.org/api/v1/users/', params={
-            'app_name': variables['api']['application'],
-            'app_key': variables['api']['key'],
-            'format': 'json',
-            'limit': 1,
-            'is_vouched': 'true'
-        })
-
-        r = r.json()
-
-        api_count = r['meta'].get('total_count')
-        home_page = Home(base_url, selenium)
-        search_results = home_page.header.search_for('')
-        results_on_page = search_results.results_count
-        number_of_pages = int(search_results.number_of_pages)
-        ui_count = results_on_page * number_of_pages
-
-        assert (ui_count - results_on_page) < api_count < (ui_count + results_on_page), u'API Count = %s : UI Count = %s.' % (api_count, ui_count)

--- a/variables.json
+++ b/variables.json
@@ -9,15 +9,10 @@
       "email": "",
       "password": "",
       "name": ""
-    },    
+    },
     "private": {
       "email": "",
       "password": "",
       "name": ""
     }
-  },
-  "api": {
-    "application": "",
-    "key": ""
-  }
 }


### PR DESCRIPTION
@davehunt / @viorelaioia r?

See https://bugzilla.mozilla.org/show_bug.cgi?id=977424#c4 - the v1 API is deprecated, now.

Ad-hoc build here: https://fx-test-jenkins-dev.stage.mozaws.net:8443/job/mozillians.adhoc/160/