### PR TITLE
Allow tests to run in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,33 +41,40 @@ for [forking a repository][git fork].
 ### Create test variables files
 
 Some of the tests require credentials associated with account with specific
-access levels. Create three username and password combinations on [staging][].
-
-Join #commtools on IRC and ask for two of these users to be vouched (or ask
-someone on #fx-test to do this for you). In one of the vouched users' profiles,
-join at least one group and mark groups as private.
+access levels. Create at least three users on [staging][]. Vouch at least two
+of these users by adding '/vouch' to the end of the profile URL for each user.
+In one of the vouched users' profiles, join at least one group and mark groups
+as private.
 
 Create a file outside of the project (to avoid accidentally exposing the
 credentials) with the following format. You will reference this file when
 running the tests using the `--variables` command line option.
 
+Note that the `vouched` key is a list. This is so that multiple vouched users
+can be used when running the tests in parallel. It's recommended that you have
+as many vouched users as you intend to have tests running in parallel.
+
 ```json
 {
-  "users": {
-    "vouched": {
-      "email": "vouched@example.com",
-      "password": "password",
-      "name": "Vouched User"
-    },
-    "unvouched": {
-      "email": "unvouced@example.com",
-      "password": "password",
-      "name": "Unvouched User"
-    },
-    "private": {
-      "email": "private@example.com",
-      "password": "password",
-      "name": "Private User"
+  "web-mozillians-staging.production.paas.mozilla.community": {
+    "users": {
+      "vouched": [
+        {
+          "username": "vouched",
+          "email": "vouched@example.com",
+          "name": "Vouched User"
+        },
+      ],
+      "unvouched": {
+        "username": "unvouched",
+        "email": "unvouched@example.com",
+        "name": "Unvouched User"
+      },
+      "private": {
+        "username": "private",
+        "email": "private@example.com",
+        "name": "Private User"
+      }
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import uuid
+from urlparse import urlparse
 
 import pytest
 
@@ -34,22 +35,23 @@ def new_user(new_email):
     return {'email': new_email}
 
 
-@pytest.fixture
-def stored_users(variables):
-    return variables['users']
+@pytest.fixture(scope='session')
+def stored_users(base_url, variables):
+    return variables[urlparse(base_url).hostname]['users']
 
 
-@pytest.fixture
-def vouched_user(stored_users):
-    return stored_users['vouched']
+@pytest.fixture(scope='function')
+def vouched_user(request, stored_users):
+    slave_id = getattr(request.config, 'slaveinput', {}).get('slaveid', 'gw0')
+    return stored_users['vouched'][int(slave_id[2:])]
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def private_user(stored_users):
     return stored_users['private']
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def unvouched_user(stored_users):
     return stored_users['unvouched']
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -208,7 +208,7 @@ class TestProfile:
     @pytest.mark.credentials
     @pytest.mark.nondestructive
     def test_private_groups_field_when_not_logged_in(self, base_url, selenium, private_user):
-        page = Profile(selenium, base_url, username=private_user['name']).open()
+        page = Profile(selenium, base_url, username=private_user['username']).open()
         assert not page.is_groups_present
 
     @pytest.mark.credentials

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands = flake8 {posargs:.}
 ignore = E501
 
 [pytest]
-addopts = --verbose -r=a --driver=Firefox
+addopts = -n=auto --verbose -r=a --driver=Firefox
 testpaths = tests
 xfail_strict = true
 base_url = https://web-mozillians-staging.production.paas.mozilla.community

--- a/variables.json
+++ b/variables.json
@@ -1,18 +1,23 @@
 {
-  "users": {
-    "vouched": {
-      "email": "",
-      "password": "",
-      "name": ""
-    },
-    "unvouched": {
-      "email": "",
-      "password": "",
-      "name": ""
-    },
-    "private": {
-      "email": "",
-      "password": "",
-      "name": ""
+  "web-mozillians-staging.production.paas.mozilla.community": {
+    "users": {
+      "vouched": [
+        {
+          "username": "",
+          "email": "",
+          "name": ""
+        },
+      ],
+      "unvouched": {
+        "username": "",
+        "email": "",
+        "name": ""
+      },
+      "private": {
+        "username": "",
+        "email": "",
+        "name": ""
+      }
     }
+  }
 }


### PR DESCRIPTION
The tests currently must execute in sequence because several of them modify the same vouched user profile. This patch resolves this by using multiple vouched users, and picks one based on the index of the process managed by pytest-xdist. Before we can merge this, we will need to modify the variables file so vouched users is a list instead of an index.

I've also introduced a basic helper script for registering users. I've registered 10 new users for staging, and we'll need to do the same for production. Ideally staging and production will use unique email addresses so the two suites can be run at the same time without the verification emails getting mixed up. To do this I'll likely introduce a hostname key to the variables file.

When running locally against staging, I got a passing suite that took just over 3 minutes. The average suite duration reported to ActiveData this year is 32 minutes.

/cc @viorelaioia @stephendonner 

* [X] Create multiple new vouched users for staging
* [x] Create unique users for production
* [x] Split the variables file by hostname
* [x] Update documentation
* [x] Vouch new production users (list sent to @viorelaioia)
* [x] Update new production private user to join a group
* [x] Upload new variables file to Jenkins ([bug 1428776](https://bugzilla.mozilla.org/show_bug.cgi?id=1428776))