### PR TITLE
Upgrade to fxtest-jenkins-pipeline v1.10

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .cache
+.git
 **/__pycache__
 **/*.pyc
 results

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN mkdir /opt
 RUN echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN apk --no-cache add \
     curl \
-    firefox@testing \
-    git
+    firefox@testing
 
 WORKDIR /src
 COPY requirements.txt /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/r
 
 COPY . /src
 
-CMD pytest
+CMD pytest --variables=/variables.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def capabilities = [
 pipeline {
   agent any
   libraries {
-    lib('fxtest@1.9')
+    lib('fxtest@1.10')
   }
   options {
     ansiColor('xterm')

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then you can run the tests using [Docker]:
   $ docker build -t mozillians-tests .
   $ docker run -it \
     --mount type=bind,source=/path/to/variables.json,destination=/variables.json,readonly \
-    mozillians-tests pytest --variables=/path/to/variables.json
+    mozillians-tests
 ```
 
 ### Run the tests using Sauce Labs
@@ -108,7 +108,7 @@ $ docker build -t mozillians-tests .
 $ docker run -it \
   --mount type=bind,source=$HOME/.saucelabs,destination=/src/.saucelabs,readonly \
   --mount type=bind,source=/path/to/variables.json,destination=/variables.json,readonly \
-  mozillians-tests pytest --variables=/path/to/variables.json
+  mozillians-tests
 ```
 
 ## Writing tests

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ as many vouched users as you intend to have tests running in parallel.
 }
 ```
 
-Then you can run the tests using [Docker]:
+Then you can run the tests using [Docker][]:
 
 ```bash
   $ docker build -t mozillians-tests .
@@ -100,16 +100,22 @@ username = username
 key = secret
 ```
 
-Then you can run the tests using [Docker][]. The `--mount` argument is
-important, as it allows your `.saucelabs` file to be accessed by the Docker container:
+Then you can run the tests against Sauce Labs using [Docker][] by passing the
+`--driver SauceLabs` argument as shown below. The `--mount` argument is
+important, as it allows your `.saucelabs` file to be accessed by the Docker
+container:
 
 ```bash
 $ docker build -t mozillians-tests .
 $ docker run -it \
   --mount type=bind,source=$HOME/.saucelabs,destination=/src/.saucelabs,readonly \
   --mount type=bind,source=/path/to/variables.json,destination=/variables.json,readonly \
-  mozillians-tests
+  mozillians-tests --variables /variables.json \
+  --driver SauceLabs --capability browserName Chrome
 ```
+
+See the documentation on [specifying capabilities][] and the Sauce Labs
+[platform configurator][] for selecting the target platform.
 
 ## Writing tests
 
@@ -127,5 +133,6 @@ things we'd like to ask you to do:
 [git clone]: https://help.github.com/articles/cloning-a-repository/
 [git fork]: https://help.github.com/articles/fork-a-repo/
 [staging]: https://web-mozillians-staging.production.paas.mozilla.community/
-[install tox]: https://tox.readthedocs.io/en/latest/install.html
+[specifying capabilities]: http://pytest-selenium.readthedocs.io/en/latest/user_guide.html#specifying-capabilities
+[platform configurator]: http://pytest-selenium.readthedocs.io/en/latest/user_guide.html#specifying-capabilities
 [style guide]: https://wiki.mozilla.org/QA/Execution/Web_Testing/Docs/Automation/StyleGuide

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ as many vouched users as you intend to have tests running in parallel.
           "username": "vouched",
           "email": "vouched@example.com",
           "name": "Vouched User"
-        },
+        }
       ],
       "unvouched": {
         "username": "unvouched",


### PR DESCRIPTION
This updates to the latest version of the shared library, which means we can remove the dependency on Git. As a result, the repository can be excluded from the Docker image, improving use of cached layers and saving a few seconds on each build stage in Jenkins.

I also fixed some README issues, most notably the Sauce Labs example wasn't actually using Sauce Labs at all.