### PR TITLE
Bump geckodriver to latest, version 0.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSLo /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/
   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
   && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
-ENV GECKODRIVER_VERSION=0.22.0
+ENV GECKODRIVER_VERSION=0.23.0
 RUN curl -fsSLo /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
   && rm -rf /opt/geckodriver \
   && tar -C /opt -zxf /tmp/geckodriver.tar.gz \


### PR DESCRIPTION
Looks like lots of goodies and things to vet, in this release: https://github.com/mozilla/geckodriver/releases/tag/v0.23.0

@jrbenny35 @hackebrot @davehunt r?